### PR TITLE
[FIX] Correctly handle socket send_to() call failures 

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -47,7 +47,7 @@ fn main() {
                     );
 
                 },
-                ClientEvent::ConnectionClosed(_) | ClientEvent::ConnectionLost => {
+                ClientEvent::ConnectionClosed(_) | ClientEvent::ConnectionLost(_) => {
                     let conn = client.connection().unwrap();
                     println!(
                         "[Client] ({}, {}ms rtt) disconnected.",

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -49,7 +49,7 @@ fn main() {
                     );
 
                 },
-                ServerEvent::ConnectionClosed(id, _) | ServerEvent::ConnectionLost(id) => {
+                ServerEvent::ConnectionClosed(id, _) | ServerEvent::ConnectionLost(id, _) => {
                     let conn = server.connection(&id).unwrap();
                     println!(
                         "[Server] Client {} ({}, {}ms rtt) disconnected.",

--- a/src/client.rs
+++ b/src/client.rs
@@ -35,9 +35,17 @@ pub enum ClientEvent {
     ConnectionFailed,
 
     /// Emitted when a existing connection to a server is lost.
-    ConnectionLost,
+    ///
+    /// The contained boolean indicates whether the connection was lost due to
+    /// an isse the remote end, if the value is `false` instead, then a local
+    /// issue caused the connection to be lost.
+    ConnectionLost(bool),
 
     /// Emitted when a connection is closed programmatically.
+    ///
+    /// The contained boolean indicates whether the connection was closed by the
+    /// remote end, if the value is `false` instead, then the connection was
+    /// closed locally.
     ConnectionClosed(bool),
 
     /// Emitted for each message received from a server.
@@ -248,8 +256,8 @@ impl<S: Socket, R: RateLimiter, M: PacketModifier> Client<S, R, M> {
                     self.events.push_back(match e {
                         ConnectionEvent::Connected => ClientEvent::Connection,
                         ConnectionEvent::FailedToConnect => ClientEvent::ConnectionFailed,
-                        ConnectionEvent::Lost => ClientEvent::ConnectionLost,
-                        ConnectionEvent::Closed(p) => ClientEvent::ConnectionClosed(p),
+                        ConnectionEvent::Lost(by_remote) => ClientEvent::ConnectionLost(by_remote),
+                        ConnectionEvent::Closed(by_remote) => ClientEvent::ConnectionClosed(by_remote),
                         ConnectionEvent::Message(payload) => ClientEvent::Message(payload),
                         ConnectionEvent::CongestionStateChanged(c) => ClientEvent::ConnectionCongestionStateChanged(c),
                         ConnectionEvent::PacketLost(payload) => ClientEvent::PacketLost(payload)

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -319,7 +319,7 @@ fn test_client_connection_loss_and_reconnect() {
     // Expect one last packet
     assert_eq!(client.socket().unwrap().sent_count(), 1);
 
-    assert_eq!(client_events(&mut client), vec![ClientEvent::ConnectionLost]);
+    assert_eq!(client_events(&mut client), vec![ClientEvent::ConnectionLost(true)]);
 
     client.send(false).ok();
     client.send(false).ok();

--- a/src/test/server.rs
+++ b/src/test/server.rs
@@ -653,7 +653,7 @@ fn test_server_connection_loss() {
     let events = server_events(&mut server);
 
     //  Connection should still be there when fetching the events
-    assert_eq!(events, vec![ServerEvent::ConnectionLost(ConnectionID(151521030))]);
+    assert_eq!(events, vec![ServerEvent::ConnectionLost(ConnectionID(151521030), true)]);
     assert!(server.connection(&ConnectionID(151521030)).is_ok());
     assert_eq!(server.connections().len(), 1);
 


### PR DESCRIPTION
These changes will treat continued send errors like any other connection failure or loss by implementing the previously described (in #4)  timeout mechanism around `send_to` calls. 

The timeout is handled via the already existing `Config::connection_drop_threshold` value and the `ConnectionLost` enum variants now contain a boolean value that indicates whether the loss was caused by the remote (i.e. no further response) or locally (i.e. unable to send over the socket for a certain amount of time).