### PR TITLE
Retrieve underlying net::UdpSocket from UdpSocket

### DIFF
--- a/src/shared/udp_socket.rs
+++ b/src/shared/udp_socket.rs
@@ -75,6 +75,15 @@ impl Socket for UdpSocket {
 
 }
 
+impl UdpSocket {
+
+    /// Returns the underlying net::UdpSocket
+    pub fn as_raw_udp_socket(&self) -> &net::UdpSocket {
+        &self.socket
+    }
+
+}
+
 impl fmt::Debug for UdpSocket {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "UdpSocket({:?})", self.socket)


### PR DESCRIPTION
With this PR, it is now possible to retrieve a ```UdpSocket```'s underlying ```net::UdpSocket```.

I need this because the default socket buffer size is too small for my UDP usage. The size can be easily changed using the crate ```net2```, but therefore it needs access to the ```net::UdpSocket```.

Thanks in advance!